### PR TITLE
Allow setting address lookup API key via 'ADDRESS_LOOKUP_TOKEN' environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,10 @@ The `SERVICE_SECRET` must then also be provided to the container running the mic
 
 :information_source: *To prevent duplication, the client secret should be defined in the `.env` file and then used in the compose files using string interpolation `"${<VARIABLE_NAME>}"`.*
 
+#### Address lookup
+
+To use UK address lookup feature an API key for https://postcodeinfo.service.justice.gov.uk is required. When API key is available it needs to be set on host side under `ADDRESS_LOOKUP_TOKEN` variable name.
+
 ## Containers
 
 ### Back-end

--- a/compose/frontend.yml
+++ b/compose/frontend.yml
@@ -28,6 +28,7 @@ services:
       IDAM_OAUTH2_CLIENT_ID: ccd_gateway
       IDAM_OAUTH2_CLIENT_SECRET: "${OAUTH2_CLIENT_CCD_GATEWAY}"
       IDAM_OAUTH2_TOKEN_ENDPOINT: http://idam-api:8080/oauth2/token
+      ADDRESS_LOOKUP_TOKEN:
       PROXY_AGGREGATED: http://ccd-data-store-api:4452
       PROXY_DATA: http://ccd-data-store-api:4452
       PROXY_DEFINITION_IMPORT: http://ccd-definition-store-api:4451


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

PR adds `ADDRESS_LOOKUP_TOKEN` to API gateway environment variables so that as long as `ADDRESS_LOOKUP_TOKEN` is set on host side it will be available for API gateway for use.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```