### PR TITLE
Fix file download

### DIFF
--- a/compose/dm-store.yml
+++ b/compose/dm-store.yml
@@ -4,15 +4,16 @@ version: '3'
 services:
   ccd-case-management-web:
     environment:
-      DM_GATEWAY_BASE_URL: http://ccd-api-gateway:3453
+      DM_URL: http://localhost:3453/documents
+      DM_URL_REMOTE: http://dm-store:8080/documents
     depends_on:
-    - dm-store
+      - dm-store
 
   ccd-api-gateway:
     environment:
       PROXY_DOCUMENT_MANAGEMENT: http://dm-store:8080
     depends_on:
-    - dm-store
+      - dm-store
 
   ccd-data-store-api:
     environment:


### PR DESCRIPTION
### JIRA link (if applicable) ###

None

### Change description ###

This PR brings back ability to download files uploaded to DM store from CCD UI.

**The problem**

File download did not work correctly because link rendered in CCD UI pointed to http://dm-store:8080/documents which is not available for user browser.

**The solution**

The solution is to set `DM_URL_REMOTE` variable so that one of the CCD UI pipes can replace http://dm-store:8080/documents with http://localhost:3453/documents (API gateway URL), an address accessible from user browser.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```