### PR TITLE
removed volume in ccd test stub service which was preventing new mapping

### DIFF
--- a/compose/backend.yml
+++ b/compose/backend.yml
@@ -190,9 +190,6 @@ services:
       - WIREMOCK_SERVER_MAPPINGS_PATH=wiremock
     ports:
       - 5555:5555
-    volumes:
-      - $WIREMOCK_SERVER_MAPPINGS_PATH:/opt/app/wiremock
 
 volumes:
   ccd-docker-ccd-shared-database-data:
-  wiremock:


### PR DESCRIPTION
files to be picked up. 

Issue Description: new mapping files are added to this git repo in `mappings` folder are not picked up by the Stub Server if run as part of compose: `./ccd compose up ccd-test-stubs-service`. 
Cause: this is caused by a volume being defined in the compose file for the service. The stub service doesn't need persistent data
hence no need for a volume. Or I can't see any valid use case for a volume here. I'll remove it



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
