### PR TITLE
fix dm store

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,6 +755,11 @@ We will need to install the az cli using Python PIP.
 
 ## Troubleshooting
 
+ccd-network could not be found error:
+
+- if you get "CCD: ERROR: Network ccd-network declared as external, but could not be found. Please create the network manually using docker network create ccd-network"
+    > ./ccd init
+
 CCD UI not loading:
 
 - it might take few minutes for all the services to startup
@@ -766,11 +771,10 @@ CCD UI not loading:
 - it's possible that some of the services cannot start or crash because of lack of availabel memory. This especially when starting Idam and or ElasticSearch
     > give more memory to Docker. Configurable under Preferences -> Advanced
 
-ccd-network could not be found error:
+DM Store issues:
 
-- if you get "CCD: ERROR: Network ccd-network declared as external, but could not be found. Please create the network manually using docker network create ccd-network"
-    > ./ccd init
-
+- "uk.gov.hmcts.dm.exception.AppConfigurationException: Cloub Blob Container does not exist"
+    > ./bin/document-management-store-create-blob-store-container.sh
 
 ## Variables
 Here are the important variables exposed in the compose files:

--- a/compose/dm-store.yml
+++ b/compose/dm-store.yml
@@ -66,7 +66,6 @@ services:
       - service-auth-provider-api
     depends_on:
       - ccd-shared-database
-#      - idam-api
       - service-auth-provider-api
       - azure-storage-emulator-azurite
     ports:

--- a/compose/dm-store.yml
+++ b/compose/dm-store.yml
@@ -50,9 +50,6 @@ services:
       http_proxy:
       https_proxy:
       no_proxy:
-      #      logging env vars
-      ROOT_APPENDER: JSON_CONSOLE
-      JSON_CONSOLE_PRETTY_PRINT: "false"
       REFORM_SERVICE_TYPE: java
       REFORM_SERVICE_NAME: document-management-store
       REFORM_TEAM: cc
@@ -69,7 +66,7 @@ services:
       - service-auth-provider-api
     depends_on:
       - ccd-shared-database
-      - idam-api
+#      - idam-api
       - service-auth-provider-api
       - azure-storage-emulator-azurite
     ports:


### PR DESCRIPTION
Fixed DM Store not working with latest image.
Removed dependency of DM Store to IDAM to allow DM starting when Idam Stub is used

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
