### PR TITLE
RDM-6251 Added ENABLE_DB_MIGRATE to dm-store.yml to make sure it is …

### DIFF
--- a/compose/dm-store.yml
+++ b/compose/dm-store.yml
@@ -59,6 +59,7 @@ services:
       PACKAGES_PROJECT: evidence
       PACKAGES_NAME: document-management-store
       PACKAGES_VERSION: unknown
+      ENABLE_DB_MIGRATE: "true"
     #      debug mode
     #    JAVA_OPTS: -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005
     links:


### PR DESCRIPTION
…always triggered.

### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-6251


### Change description ###
Just added an environment variable ENABLE_DB_MIGRATE that defaults to true to run Liquibase in dm-store.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
