### PR TITLE
Fixed admin web environment prefix.

### DIFF
--- a/ccd
+++ b/ccd
@@ -41,7 +41,7 @@ function project_config() {
         ccd-admin-web|admin-web|admin-web)
             name=ccd-admin-web
             repository="git@github.com:hmcts/ccd-admin-web.git"
-            envPrefix="CCD-ADMIN-WEB"
+            envPrefix="CCD_ADMIN_WEB"
             ;;
         dm-store|document-store)
             name=dm-store


### PR DESCRIPTION
./ccd compose ps complains that the identifier **CCD-ADMIN-WEB** is invalid. Changed this to **CCD_ADMIN_WEB** to make it consistent with identifiers for the other components.


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
