### PR TITLE
ACA-112 - set env var used to define callback URLs

### DIFF
--- a/bin/env_variables_all.txt
+++ b/bin/env_variables_all.txt
@@ -84,3 +84,4 @@ TEST_URL=http://localhost:4452
 USER=someuser
 USER_PROFILE_HOST=http://ccd-user-profile-api:4453
 USER_PROFILE_S2S_AUTHORISED_SERVICES=ccd_data,ccd_definition,ccd_admin
+TEST_STUB_SERVICE_BASE_URL=http://host.docker.internal:5555


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ACA-112

### Change description ###

Adds environment variable that is used by `befta-fw` to define callback URLs within the definition file, before it is imported to definition store, when FTA tests are run

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
