### PR TITLE
RDM-12686 add ref-data URL to data-store env vars

### DIFF
--- a/compose/backend.yml
+++ b/compose/backend.yml
@@ -96,6 +96,7 @@ services:
       ENABLE_ATTRIBUTE_BASED_ACCESS_CONTROL: "${ENABLE_ATTRIBUTE_BASED_ACCESS_CONTROL:-false}"
       ENABLE_PSEUDO_ROLE_ASSIGNMENTS_GENERATION: "${ENABLE_PSEUDO_ROLE_ASSIGNMENTS_GENERATION:-false}"
       ENABLE_PSEUDO_ACCESS_PROFILES_GENERATION: "${ENABLE_PSEUDO_ACCESS_PROFILES_GENERATION:-false}"
+      REFERENCE_DATA_API_URL: "${RD_LOCATION_REF_API_BASE_URL:-http://ccd-test-stubs-service:5555}"
       ROLE_ASSIGNMENT_URL: "${ROLE_ASSIGNMENT_URL:-http://am-role-assignment-service:4096}"
       # Uncomment this line to enable JVM debugging and uncomment the port mapping below
       # JAVA_TOOL_OPTIONS: '-XX:InitialRAMPercentage=30.0 -XX:MaxRAMPercentage=65.0 -XX:MinRAMPercentage=30.0 -XX:+UseConcMarkSweepGC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005'


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [RDM-12686](https://tools.hmcts.net/jira/browse/RDM-12686) _"Establish the new Global Search endpoint"_

### Change description ###

Add URL to Reference Data APIs to the data-store's environment variables

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
