### PR TITLE
Fix IdAM stub for use with ExUI

### DIFF
--- a/compose/backend.yml
+++ b/compose/backend.yml
@@ -247,7 +247,8 @@ services:
 # provide custom Idam roles when using Idam Stub.
 # uncomment and add the desired roles to idam_stub_get_details_custom.json. Then restart the Stub Service
 #    volumes:
-#      - ${PWD}/resources/idam_stub_get_details_custom.json:/opt/app/wiremock/mappings/idam_get_details.json
+#      - ${PWD}/resources/idam_stub_get_details_custom.json:/opt/app/wiremock/mappings/idam/idam_get_details.json
+#      - ${PWD}/resources/idam_stub_get_userinfo_custom.json:/opt/app/wiremock/mappings/idam/idam_get_userinfo.json
 
 volumes:
   ccd-docker-ccd-shared-database-data:

--- a/resources/idam_stub_get_userinfo_custom.json
+++ b/resources/idam_stub_get_userinfo_custom.json
@@ -1,7 +1,7 @@
 {
   "request": {
     "method": "GET",
-    "urlPath": "/details"
+    "urlPath": "/o/userinfo"
   },
   "response": {
     "status": 200,
@@ -9,16 +9,16 @@
       "Content-Type": "application/json"
     },
     "jsonBody": {
-      "sub": "auto.test.cnp@gmail.com",
-      "uid": "123456",
+      "email": "auto.test.cnp@gmail.com",
       "roles": [
         "caseworker-autotest1",
         "caseworker-autotest2",
         "caseworker",
-        "ccd-import",
-        "caseworker-divorce"
+        "ccd-import"
       ],
-      "name": "CCD",
+      "sub": "auto.test.cnp@gmail.com",
+      "uid": "7689",
+      "name": "CCD Auto Test (Stub)",
       "given_name": "CCD",
       "family_name": "Auto Test (Stub)"
     }


### PR DESCRIPTION
### Change description ###
This change is to fix a problem with the IdAM stub when using ExUI.

The IdAM stub doesn't work with ExUI for create case events - the events aren't displayed in ExUI Create Case dropdown.
This is because the custom stub config in ccd-docker is out of alignment with ccd-test-stubs-service:

1. The mapping path is wrong - it needs to include "idam". See https://github.com/hmcts/ccd-test-stubs-service/tree/master/wiremock/mappings
2. The custom get details response has the wrong URL path. See https://github.com/hmcts/ccd-test-stubs-service/blob/master/wiremock/mappings/idam/idam_get_details.json
3. An additional custom response is required for /o/userinfo. See https://github.com/hmcts/ccd-test-stubs-service/blob/master/wiremock/mappings/idam/idam_get_userinfo.json


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
