### PR TITLE
RDM-12847 - enable testing support endpoint when testing locally

### DIFF
--- a/compose/backend.yml
+++ b/compose/backend.yml
@@ -98,6 +98,7 @@ services:
       ENABLE_PSEUDO_ACCESS_PROFILES_GENERATION: "${ENABLE_PSEUDO_ACCESS_PROFILES_GENERATION:-false}"
       REFERENCE_DATA_API_URL: "${RD_LOCATION_REF_API_BASE_URL:-http://ccd-test-stubs-service:5555}"
       ROLE_ASSIGNMENT_URL: "${ROLE_ASSIGNMENT_URL:-http://am-role-assignment-service:4096}"
+      TESTING_SUPPORT_ENABLED: "true"
       # Uncomment this line to enable JVM debugging and uncomment the port mapping below
       # JAVA_TOOL_OPTIONS: '-XX:InitialRAMPercentage=30.0 -XX:MaxRAMPercentage=65.0 -XX:MinRAMPercentage=30.0 -XX:+UseConcMarkSweepGC -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005'
     ports:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDM-12847
https://tools.hmcts.net/jira/browse/RDM-12851

### Change description ###

Enable testing support endpoint when testing locally

Required to check case links exist in DB for FTA/Befta tests

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
