### PR TITLE
WLTS-31 Add new translation-service env vars

### DIFF
--- a/compose/ts-translation-service.yml
+++ b/compose/ts-translation-service.yml
@@ -23,6 +23,7 @@ services:
       REFORM_SERVICE_NAME: ts-translation-service
       REFORM_TEAM: ts
       REFORM_ENVIRONMENT: local
+      TESTING_SUPPORT_ENABLED: "${TESTING_SUPPORT_ENABLED:-true}"
       APPINSIGHTS_INSTRUMENTATIONKEY: key
     ports:
       - "4650:4650"


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [WLTS-31](https://tools.hmcts.net/jira/browse/WLTS-31) _"Automate clear down of test data generated by Functional Tests"_

### Change description ###

Add new translation-service environment variables:
* `TESTING_SUPPORT_ENABLED` for FTAs for WLTS-31 (hmcts/ts-translation-service#60) 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
